### PR TITLE
xCredSSP: Vanilla server registry issue fix (Fixes #17)

### DIFF
--- a/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
+++ b/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
@@ -191,9 +191,10 @@ function Set-TargetResource
                     {
                         $key = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowFreshCredentials"
 			
-			if (!(test-path $key)){
-				New-Item $key -Force
-			}
+			            if (!(test-path $key))
+                        {
+				            New-Item $key -Force | out-null
+			            }
 
                         $CurrentDelegateComputers = @()
 
@@ -207,25 +208,25 @@ function Set-TargetResource
 
                         foreach($DelegateComputer in $DelegateComputers)
                         {
-			    if($CurrentDelegateComputers -eq $NULL)
-			    {
-                            	Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
-                            	if ($SuppressReboot -eq $false)
-                            	{
-                                $global:DSCMachineStatus = 1
-                            	}
-			    }
-			    else
-			    {
-			    	if(!$CurrentDelegateComputers.Contains($DelegateComputer))
-                            	{
-                                	Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
-                                	if ($SuppressReboot -eq $false)
-                                	{
-                                    		$global:DSCMachineStatus = 1
-                                	}
-                            	}
-			    }
+			                if($CurrentDelegateComputers -eq $NULL)
+			                {
+                                Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
+                                if ($SuppressReboot -eq $false)
+                                {
+                                    $global:DSCMachineStatus = 1
+                                }
+			                }
+			                else
+			                {
+			    	            if(!$CurrentDelegateComputers.Contains($DelegateComputer))
+                                {
+                                    Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
+                                    if ($SuppressReboot -eq $false)
+                                    {
+                                        $global:DSCMachineStatus = 1
+                                    }
+                                }
+			                }
                         }
                     }
                     else

--- a/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
+++ b/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
@@ -190,7 +190,7 @@ function Set-TargetResource
                     if($DelegateComputers)
                     {
                         $key = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowFreshCredentials"
-			
+
                         if (!(test-path $key))
                         {
                             New-Item $key -Force | out-null

--- a/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
+++ b/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
@@ -190,6 +190,10 @@ function Set-TargetResource
                     if($DelegateComputers)
                     {
                         $key = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowFreshCredentials"
+			
+			if (!(test-path $key)){
+				New-Item $key -Force
+			}
 
                         $CurrentDelegateComputers = @()
 
@@ -203,14 +207,25 @@ function Set-TargetResource
 
                         foreach($DelegateComputer in $DelegateComputers)
                         {
-                            if(!$CurrentDelegateComputers.Contains($DelegateComputer))
-                            {
-                                Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
-                                if ($SuppressReboot -eq $false)
-                                {
-                                    $global:DSCMachineStatus = 1
-                                }
-                            }
+			    if($CurrentDelegateComputers -eq $NULL)
+			    {
+                            	Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
+                            	if ($SuppressReboot -eq $false)
+                            	{
+                                $global:DSCMachineStatus = 1
+                            	}
+			    }
+			    else
+			    {
+			    	if(!$CurrentDelegateComputers.Contains($DelegateComputer))
+                            	{
+                                	Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
+                                	if ($SuppressReboot -eq $false)
+                                	{
+                                    		$global:DSCMachineStatus = 1
+                                	}
+                            	}
+			    }
                         }
                     }
                     else

--- a/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
+++ b/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
@@ -86,7 +86,8 @@ function Get-TargetResource
 
                     $DelegateComputers = @()
 
-                    Get-Item -Path $key |
+
+                    Get-Item -Path $key -ErrorAction SilentlyContinue |
                         Select-Object -ExpandProperty Property | 
                         ForEach-Object {
                             $DelegateComputer = ((Get-ItemProperty -Path $key -Name $_).$_).Split("/")[1]
@@ -208,23 +209,12 @@ function Set-TargetResource
 
                         foreach($DelegateComputer in $DelegateComputers)
                         {
-                            if($CurrentDelegateComputers -eq $NULL)
+                            if(($CurrentDelegateComputers -eq $NULL) -or (!$CurrentDelegateComputers.Contains($DelegateComputer)))
                             {
                                 Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
                                 if ($SuppressReboot -eq $false)
                                 {
                                    $global:DSCMachineStatus = 1
-                                }
-                            }
-                            else
-                            {
-                                if(!$CurrentDelegateComputers.Contains($DelegateComputer))
-                                {
-                                    Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
-                                    if ($SuppressReboot -eq $false)
-                                    {
-                                        $global:DSCMachineStatus = 1
-                                    }
                                 }
                             }
                         }

--- a/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
+++ b/DSCResources/MSFT_xCredSSP/MSFT_xCredSSP.psm1
@@ -191,10 +191,10 @@ function Set-TargetResource
                     {
                         $key = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowFreshCredentials"
 			
-			            if (!(test-path $key))
+                        if (!(test-path $key))
                         {
-				            New-Item $key -Force | out-null
-			            }
+                            New-Item $key -Force | out-null
+                        }
 
                         $CurrentDelegateComputers = @()
 
@@ -208,17 +208,17 @@ function Set-TargetResource
 
                         foreach($DelegateComputer in $DelegateComputers)
                         {
-			                if($CurrentDelegateComputers -eq $NULL)
-			                {
+                            if($CurrentDelegateComputers -eq $NULL)
+                            {
                                 Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
                                 if ($SuppressReboot -eq $false)
                                 {
-                                    $global:DSCMachineStatus = 1
+                                   $global:DSCMachineStatus = 1
                                 }
-			                }
-			                else
-			                {
-			    	            if(!$CurrentDelegateComputers.Contains($DelegateComputer))
+                            }
+                            else
+                            {
+                                if(!$CurrentDelegateComputers.Contains($DelegateComputer))
                                 {
                                     Enable-WSManCredSSP -Role Client -DelegateComputer $DelegateComputer -Force | Out-Null
                                     if ($SuppressReboot -eq $false)
@@ -226,7 +226,7 @@ function Set-TargetResource
                                         $global:DSCMachineStatus = 1
                                     }
                                 }
-			                }
+                            }
                         }
                     }
                     else

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The **xCredSSP** module contains the **xCredSSP** resource, which enables or dis
 ## Versions
 
 ### Unreleased
+* Added a fix to enable credSSP with a fresh server installation
 
 ### 1.2.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.


### PR DESCRIPTION
Added code to fix the issue when enabling credSSP on a fresh Server installation where registry keys are not present yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcredssp/18)
<!-- Reviewable:end -->
